### PR TITLE
v1.0 changes of open(command, ...) function

### DIFF
--- a/src/compressed_file.jl
+++ b/src/compressed_file.jl
@@ -10,18 +10,18 @@ Base.open(file::CompressedFile, mode::AbstractString = "r") = begin
 
     if mode == "r"
         if endswith(filename, ".gz")
-            open(`gzip -d -c $filename`, "r", STDOUT)[1]
+            open(`gzip -d -c $filename`, "r", stdout)
         elseif endswith(filename, ".bz2")
             try
-                open(`pbzip2 -d -c $filename`, "r", STDOUT)[1]
+                open(`pbzip2 -d -c $filename`, "r", stdout)
             catch
                 info("pbzip2 doesn't seem to be available, falling back to standard bzip2")
-                open(`bzip2 -d -c $filename`, "r", STDOUT)[1]
+                open(`bzip2 -d -c $filename`, "r", stdout)
             end
         elseif endswith(filename, ".xz")
-            open(`xz -d -c $filename`, "r", STDOUT)[1]
+            open(`xz -d -c $filename`, "r", stdout)
         else
-            open(`cat $filename`, "r", STDOUT)[1]
+            open(`cat $filename`, "r", stdout)
         end
     else
         @assert false


### PR DESCRIPTION
STDOUT -> stdout

The open(cmd, ..)-method we use does not return a tuple anymore, but only a Process -> Removed the [1].